### PR TITLE
docs: add missing explanation of burn fees

### DIFF
--- a/gitbook/smart-contracts/liquidity-hub/pool-network/terraswap-pair.md
+++ b/gitbook/smart-contracts/liquidity-hub/pool-network/terraswap-pair.md
@@ -42,9 +42,13 @@ A user or bot can provide liquidity by sending a `provide_liquidity` message and
 
 ## Fees
 
-There are two types of fees associated to the pools, namely `swap_fee` and `protocol_fee`. The `swap_fee` remains in the pool, causing a permanent increase in the constant product K. The value of this permanently increased pool goes to all LPs.
+There are three types of fees associated to the pools, namely `swap_fee`, `protocol_fee` and `burn_fee`. The `swap_fee` 
+remains in the pool, causing a permanent increase in the constant product K. The value of this permanently increased pool goes to all LPs.
 
-The `protocol_fee` goes to the protocol, and it is to be collected by the Fee Collector contract of the Liquidity Hub. The protocol revenue is then distributed to WHALE stakers in the form of token buybacks.
+The `protocol_fee` goes to the protocol, and it is to be collected by the Fee Collector contract of the Liquidity Hub. 
+The protocol revenue is then distributed to WHALE stakers in the form of token buybacks.
+
+The `burn_fee` is a percentage of the tokens that is burned whenever a swap takes place.
 
 ## Feature toggle
 

--- a/gitbook/smart-contracts/liquidity-hub/vault-network/vault.md
+++ b/gitbook/smart-contracts/liquidity-hub/vault-network/vault.md
@@ -6,11 +6,13 @@ Flash loan vaults are a great source of yield with no impermanent loss.
 
 ## Fees
 
-There are two types of fees associated to the vaults, namely `flash_loan_fee` and `protocol_fee`. The `flash_loan_fee` 
+There are three types of fees associated to the vaults, namely `flash_loan_fee`, `protocol_fee` and `burn_fee`. The `flash_loan_fee` 
 remains in the vault, which makes the share's value of the liquidity provides to increase, benefiting all LPs.
 
 The `protocol_fee` goes to the protocol, and it is to be collected by the Fee Collector contract of the Liquidity Hub.
 The protocol revenue is then distributed to WHALE stakers in the form of token buybacks.
+
+The `burn_fee` is used to burn a portion of the tokens when a flash-loan takes place.
 
 ## Feature toggle
 


### PR DESCRIPTION
This PR adds missing burn fees explanation on pools and vaults.