### PR TITLE
docs: rebrand from Migaloo to White Whale

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 <a href="https://whitewhale.money/">
   <h1 align="center">
     <picture>
-      <img alt="White Whale Migaloo" src="https://miro.medium.com/max/1400/1*29OYRJqqddosWtWo-c3TYQ.png">
+      <img alt="White Whale V2" src="https://miro.medium.com/max/1400/1*29OYRJqqddosWtWo-c3TYQ.png">
     </picture>
   </h1>
 </a>
@@ -17,18 +17,19 @@
 [Twitter handle]: https://img.shields.io/twitter/follow/WhiteWhaleDefi.svg?style=social&label=Follow
 [Twitter badge]: https://twitter.com/intent/follow?screen_name=WhiteWhaleDefi
 
-# Migaloo Docs
-This repository contains the public-facing documentation of the open-source and decentralized Migaloo Protocol. Here you will find both general information and specific documentation on our repositories:
-- [Migaloo Smart Contracts](https://github.com/White-Whale-Defi-Platform/migaloo-core/)
-- [Migaloo Frontend](https://github.com/White-Whale-Defi-Platform/migaloo-frontend/)
-- [Migaloo Bots](https://github.com/White-Whale-Defi-Platform/migaloo-bots/)
+# White Whale Docs
+This repository contains the public-facing documentation of the open-source and decentralized White Whale Protocol. 
+Here you will find both general information and specific documentation on our repositories:
+- [White Whale Smart Contracts](https://github.com/White-Whale-Defi-Platform/white-whale-core/)
+- [White Whale Frontend](https://github.com/White-Whale-Defi-Platform/white-whale-frontend/)
+- [White Whale Bots](https://github.com/White-Whale-Defi-Platform/white-whale-bots/)
 
 If you are looking for our V1 documentation, you can find it [here](https://white-whale-defi-platform.github.io/docs/).
 
 ## Resources
 1. [Website](https://whitewhale.money/)
 2. [LitePaper](https://whitewhale.money/LitepaperV2.pdf)
-3. [Docs](https://ww0-1.gitbook.io/migaloo-docs/)
+3. [Docs](https://docs.whitewhale.money/white-whale-docs/)
 4. [Discord](https://discord.com/invite/tSxyyCWgYX)
 5. [Twitter](https://twitter.com/WhiteWhaleDefi)
 6. [Telegram](https://t.me/whitewhaleofficial)

--- a/SUMMARY.md
+++ b/SUMMARY.md
@@ -2,7 +2,7 @@
 
 * [👋 Welcome](./README.md)
 * [📜 Abstract](./gitbook/general/abstract.md)
-* [🚀 Migaloo's Vision](./gitbook/general/vision.md)
+* [🚀 White Whale's Vision](./gitbook/general/vision.md)
 * [🌉 Architecture](./gitbook/general/architecture.md)
 * [🐞 Bug Bounty Program](./gitbook/general/bug-bounty-program.md)
 
@@ -37,5 +37,5 @@
 * [⚡ Calling Flashloans](./gitbook/client-docs/flashloan.md)
   * [Example](./gitbook/client-docs/flashloan_example.md)
 * [🤖 Arbitrage Bots](./gitbook/client-docs/arbitrage_bots.md)
-  * [⚙️   Config Example](./gitbook//client-docs//configexample.md)
-  * [🐳 Running in Docker](./gitbook//client-docs//docker_deployment_bots.md)
+  * [⚙️ Config Example](./gitbook/client-docs/configexample.md)
+  * [🐳 Running in Docker](./gitbook/client-docs/docker_deployment_bots.md)

--- a/gitbook/client-docs/arbitrage_bots.md
+++ b/gitbook/client-docs/arbitrage_bots.md
@@ -5,7 +5,7 @@
 
 + Install [NodeJS]() and make sure its added to Path
 + Install your favorite IDE that supports TypeScript (Like VSCode)
-+ Clone the White Whale Bot [repository](https://github.com/White-Whale-Defi-Platform/migaloo-bots) to your machine
++ Clone the White Whale Bot [repository](https://github.com/White-Whale-Defi-Platform/white-whale-bots) to your machine
 + Open the repository folder in your IDE as root folder
 + In Console type `npm install` to make sure the required packages are added to the project
 + In Console type `npm run build` to build the project for the first time

--- a/gitbook/general/architecture.md
+++ b/gitbook/general/architecture.md
@@ -2,6 +2,6 @@
 
 The White Whale protocol consists of 2 main components: the Liquidity Hubs and the Interchain Command.
 
-<figure><img src=".gitbook/assets/architecture.png" alt="White Whale Migaloo&#x27;s Architecture"><figcaption><p>Migaloo's Architecture</p></figcaption></figure>
+<figure><img src=".gitbook/assets/architecture.png" alt="White Whale&#x27;s Architecture"><figcaption><p>White Whale's Architecture</p></figcaption></figure>
 
 Detailed information about the functionalities of all components can be found on the [litepaper](https://whitewhale.money/LitepaperV2.pdf).

--- a/gitbook/general/bug-bounty-program.md
+++ b/gitbook/general/bug-bounty-program.md
@@ -1,8 +1,8 @@
 # Bug Bounty Program
 The White Whale Bug Bounty Program encourages developers and researchers to find and report bugs in the following repositories:
-- [Migaloo Core](https://github.com/White-Whale-Defi-Platform/migaloo-core)
-- [Migaloo Front-End](https://github.com/White-Whale-Defi-Platform/migaloo-frontend)
-- [Migaloo Bots](https://github.com/White-Whale-Defi-Platform/migaloo-bots)
+- [White Whale Core](https://github.com/White-Whale-Defi-Platform/white-whale-core)
+- [White Whale Front-End](https://github.com/White-Whale-Defi-Platform/white-whale-frontend)
+- [White Whale Bots](https://github.com/White-Whale-Defi-Platform/white-whale-bots)
 
 Before reporting a bug, please read this document carefully!
 

--- a/gitbook/general/vision.md
+++ b/gitbook/general/vision.md
@@ -1,4 +1,4 @@
-# Migaloo's Vision
+# White Whale's Vision
 
 ## Problem in Cosmos Ecosystem
 

--- a/gitbook/smart-contracts/common-types/overview.md
+++ b/gitbook/smart-contracts/common-types/overview.md
@@ -1,6 +1,6 @@
 # Common Types
 
-The following are common data types used across Migaloo contracts. There might be few more that are used internally, though 
+The following are common data types used across White Whale's contracts. There might be few more that are used internally, though 
 this list contains the types that are exposed via the entry points.
 
 | Struct               | Description                                                    | Contains                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                |

--- a/gitbook/smart-contracts/liquidity-hub/fee-collector.md
+++ b/gitbook/smart-contracts/liquidity-hub/fee-collector.md
@@ -6,7 +6,7 @@ remainder is sent to the interchain collector as protocol revenue. The protocol 
 stakers in the form of token buybacks.
 
 The code for the fee collector contract can be
-found [here](https://github.com/White-Whale-Defi-Platform/migaloo-core/tree/main/contracts/liquidity_hub/fee_collector).
+found [here](https://github.com/White-Whale-Defi-Platform/white-whale-core/tree/main/contracts/liquidity_hub/fee_collector).
 
 ---
 

--- a/gitbook/smart-contracts/liquidity-hub/pool-network/overview.md
+++ b/gitbook/smart-contracts/liquidity-hub/pool-network/overview.md
@@ -10,7 +10,7 @@ effectively decreases price disparities. Currently, users can find price dispari
 White Whale's pool network is based on [Terraswap](https://github.com/terraswap/terraswap), a Uniswap-inspired automated 
 market-maker (AMM) protocol.
 
-The code for the pool network can be found [here](https://github.com/White-Whale-Defi-Platform/migaloo-core/tree/main/contracts/liquidity_hub/pool-network). 
+The code for the pool network can be found [here](https://github.com/White-Whale-Defi-Platform/white-whale-core/tree/main/contracts/liquidity_hub/pool-network). 
 
 ## Contracts
 
@@ -38,7 +38,7 @@ cargo build
 cargo wasm
 ```
 
-Or for a production-ready (optimized) build, run the following from the `migaloo-core` repository:
+Or for a production-ready (optimized) build, run the following from the `white-whale-core` repository:
 
 ```
 scripts/build_release.sh

--- a/gitbook/smart-contracts/liquidity-hub/pool-network/terraswap-factory.md
+++ b/gitbook/smart-contracts/liquidity-hub/pool-network/terraswap-factory.md
@@ -1,6 +1,6 @@
 # Factory
 
-Migaloo's factory contract is used to create pair (pool) contracts. Pools are comprised of two tokens, which can be either 
+White Whale's factory contract is used to create pair (pool) contracts. Pools are comprised of two tokens, which can be either 
 native, ibc or cw20 tokens. Once a pool is created it's stored in state, meaning the factory acts as a pool registry, which 
 can be queried for reference. Note that **the pool factory is permissioned**, meaning the messages can only be executed by the 
 owner of the contract.
@@ -11,7 +11,7 @@ Creating a pair (pool) can be done via the `create_pair` message. Note that for 
 `add_native_token_decimals` should be called in advance with a small amount of the desired asset (say one micro unit). This 
 is used to whitelist native/ibc tokens, allowing pools to be created with those.
 
-The code for the Factory contract can be found [here](https://github.com/White-Whale-Defi-Platform/migaloo-core/tree/main/contracts/liquidity_hub/pool-network/terraswap_factory).
+The code for the Factory contract can be found [here](https://github.com/White-Whale-Defi-Platform/white-whale-core/tree/main/contracts/liquidity_hub/pool-network/terraswap_factory).
 
 ---
 

--- a/gitbook/smart-contracts/liquidity-hub/pool-network/terraswap-pair.md
+++ b/gitbook/smart-contracts/liquidity-hub/pool-network/terraswap-pair.md
@@ -54,7 +54,7 @@ The `burn_fee` is a percentage of the tokens that is burned whenever a swap take
 
 Pools contain a feature toggle, containing the following properties: `withdrawals_enabled`, `deposits_enabled` and `swaps_enabled`. Those features are \`ON by default, but could be changed via governance. They could be changed in different scenarios, the ones we could envision include for example if a critical bug is found in a given feature, it could be shut down while is being fixed to avoid exploits. Additionally, if for example liquidity is desired to be migrated to another pool, deposits could be disabled to prevent bots or users to deposit liquidity in the pool.
 
-The code for the pair contract can be found [here](https://github.com/White-Whale-Defi-Platform/migaloo-core/tree/main/contracts/liquidity\_hub/pool-network/terraswap\_pair).
+The code for the pair contract can be found [here](https://github.com/White-Whale-Defi-Platform/white-whale-core/tree/main/contracts/liquidity\_hub/pool-network/terraswap\_pair).
 
 ***
 

--- a/gitbook/smart-contracts/liquidity-hub/pool-network/terraswap-router.md
+++ b/gitbook/smart-contracts/liquidity-hub/pool-network/terraswap-router.md
@@ -6,7 +6,7 @@ swap operations so that it becomes possible to swap ATOM for LUNA via JUNO, i.e.
 
 The router is mainly used by bots and the UI.
 
-The code for the router contract can be found [here](https://github.com/White-Whale-Defi-Platform/migaloo-core/tree/main/contracts/liquidity_hub/pool-network/terraswap_router).
+The code for the router contract can be found [here](https://github.com/White-Whale-Defi-Platform/white-whale-core/tree/main/contracts/liquidity_hub/pool-network/terraswap_router).
 
 ---
 

--- a/gitbook/smart-contracts/liquidity-hub/pool-network/terraswap-token.md
+++ b/gitbook/smart-contracts/liquidity-hub/pool-network/terraswap-token.md
@@ -6,7 +6,7 @@ contracts that wish to implement this spec, or by contracts that call to any sta
 
 The token contract is used by the pool contract to create LP tokens.
 
-The code for the token contract can be found [here](https://github.com/White-Whale-Defi-Platform/migaloo-core/tree/main/contracts/liquidity_hub/pool-network/terraswap_token).
+The code for the token contract can be found [here](https://github.com/White-Whale-Defi-Platform/white-whale-core/tree/main/contracts/liquidity_hub/pool-network/terraswap_token).
 
 ---
 

--- a/gitbook/smart-contracts/liquidity-hub/vault-network/overview.md
+++ b/gitbook/smart-contracts/liquidity-hub/vault-network/overview.md
@@ -11,7 +11,7 @@ used any of their own capital.
 Depositors of tokens into flash loan vaults benefit from fees paid when their vault is accessed for flash loans; 
 the greater the volume, the more fees generated. Flash loan vaults are a great source of yield with no impermanent loss.
 
-The code for the vault network can be found [here](https://github.com/White-Whale-Defi-Platform/migaloo-core/tree/main/contracts/liquidity_hub/vault-network).
+The code for the vault network can be found [here](https://github.com/White-Whale-Defi-Platform/white-whale-core/tree/main/contracts/liquidity_hub/vault-network).
 
 ## Contracts
 

--- a/gitbook/smart-contracts/liquidity-hub/vault-network/vault-factory.md
+++ b/gitbook/smart-contracts/liquidity-hub/vault-network/vault-factory.md
@@ -6,7 +6,7 @@ meaning
 the messages can only be executed by the owner of the contract.
 
 The code for the vault factory contract can be
-found [here](https://github.com/White-Whale-Defi-Platform/migaloo-core/tree/main/contracts/liquidity_hub/vault-network/vault_factory)
+found [here](https://github.com/White-Whale-Defi-Platform/white-whale-core/tree/main/contracts/liquidity_hub/vault-network/vault_factory)
 .
 
 ---

--- a/gitbook/smart-contracts/liquidity-hub/vault-network/vault-router.md
+++ b/gitbook/smart-contracts/liquidity-hub/vault-network/vault-router.md
@@ -7,7 +7,7 @@ will take care of communicating and requesting the funds to the appropriate vaul
 An interesting feature that the White Whale Vault Router is pioneering is the possibility to take multiple flash loans at 
 once.
 
-The code for the vault router can be found [here](https://github.com/White-Whale-Defi-Platform/migaloo-core/tree/main/contracts/liquidity_hub/vault-network/vault_router).
+The code for the vault router can be found [here](https://github.com/White-Whale-Defi-Platform/white-whale-core/tree/main/contracts/liquidity_hub/vault-network/vault_router).
 
 ---
 

--- a/gitbook/smart-contracts/liquidity-hub/vault-network/vault.md
+++ b/gitbook/smart-contracts/liquidity-hub/vault-network/vault.md
@@ -22,7 +22,7 @@ we could envision include for example if a critical bug is found in a given feat
 fixed to avoid exploits. Additionally, if for example liquidity is desired to be migrated to another pool, deposits could
 be disabled to prevent bots or users to deposit liquidity in the pool.
 
-The code for the vault contract can be found [here](https://github.com/White-Whale-Defi-Platform/migaloo-core/tree/main/contracts/liquidity_hub/vault-network/vault).
+The code for the vault contract can be found [here](https://github.com/White-Whale-Defi-Platform/white-whale-core/tree/main/contracts/liquidity_hub/vault-network/vault).
 
 ---
 

--- a/gitbook/smart-contracts/overview.md
+++ b/gitbook/smart-contracts/overview.md
@@ -1,6 +1,6 @@
 # Summary of Smart Contracts
 
-The following is a general overview of the smart contracts used by Migaloo:
+The following is a general overview of the smart contracts used by White Whale:
 
 - **Pool network**: a coordinated network of LPs (e.g., Atom-Luna; and Atom-Juno) for each supported token on selected 
 chains (e.g., Terra and Juno)


### PR DESCRIPTION
This PR changes all the Migaloo instances to White Whale, as Migaloo refers now to the chain while White Whale to the protocol.